### PR TITLE
Fix link to new YouTube channel

### DIFF
--- a/content/live-streams/december-10-2021.org
+++ b/content/live-streams/december-10-2021.org
@@ -37,4 +37,4 @@ In the meantime, I'll be doing some light configuration hacking for a couple of 
 - [[https://mitpress.mit.edu/sites/default/files/sicp/full-text/book/book.html][SICP]]
   - [[https://www.youtube.com/playlist?list=PLB63C06FAF154F047][SICP YouTube Playlist]]
 - https://github.com/fritzgrabo/project-tab-groups
-- [[https://www.youtube.com/playlist?list=PLB63C06FAF154F047][My second YouTube channel]]
+- [[https://www.youtube.com/channel/UCZ4HO8or08HUGUzA0w8Tagw][My second YouTube channel]]


### PR DESCRIPTION
Catched up with your live stream the last days and wanted to subscribe to your new YouTube channel by clicking the link in the show notes. While it was indeed a YouTube link it took me to the SICP YouTube playlist like the URL two lines above. I took the link from your notes from the live stream on 2021-11-26 and replaced it.

I hope you don't mind the PR. Should I've written you an email instead?

Thanks for the great content, btw.!