### PR TITLE
Fix stow command in stow shownotes

### DIFF
--- a/content/managing-your-dotfiles/using-gnu-stow.org
+++ b/content/managing-your-dotfiles/using-gnu-stow.org
@@ -71,11 +71,12 @@ This means that =stow .= is equivalent to:
 
 #+begin_src sh
 
-  stow --dir=~/.dotfiles --target=~/
+  # dot here is a relative path to --dir and you have to put it
+  stow -S . --dir=~/.dotfiles --target=~/
 
   # OR
 
-  stow -d ~/.dotfiles -t ~/
+  stow . -d ~/.dotfiles -t ~/
 
 #+end_src
 


### PR DESCRIPTION
Previously that stow commands would output and error 
`stow: No packages to stow or unstow`

Now these commands are correct.

PS:
I really appreciate you work!